### PR TITLE
Never instantiate components unless needed + some cleanup

### DIFF
--- a/lib/diversity/registry/local.rb
+++ b/lib/diversity/registry/local.rb
@@ -121,20 +121,6 @@ module Diversity
         @options[:mode]
       end
 
-      # Removes a locally installed component from the file system
-      #
-      # @param [String] name Component name
-      # @param [Gem::Version|String|nil] version
-      # @return [Array] An array of the versions that were removed
-      def uninstall_component(name, version = nil)
-        uninstalled_versions = []
-        get_matching_components(name, version).each do |comp|
-          uninstalled_versions << comp.version
-          fileutils.rm_rf(comp.base_path) #fixme
-        end
-        uninstalled_versions
-      end
-
       private
 
       # Returns a suitable module for doing file operations

--- a/spec/components/dummy/0.0.1/diversity.json
+++ b/spec/components/dummy/0.0.1/diversity.json
@@ -1,21 +1,16 @@
 {
   "name": "dummy",
   "version": "0.0.1",
-  "type": "object",
   "thumbnail": "dummy.png",
   "angular": "dummy",
   "template": "dummy.html",
-  "partials": {},
   "context": {},
   "style": "css/dummy.css",
-  "themes": [],
   "script": ["js/dummy1.js", "js/dummy2.js"],
   "i18n": {},
   "l10n": {},
-  "fields": {},
   "settings": {},
   "dependencies": {
     "something-special": ">0.0.1"
-  },
-  "assetDir": "assets"
+  }
 }

--- a/spec/components/something-special/0.5.5/diversity.json
+++ b/spec/components/something-special/0.5.5/diversity.json
@@ -1,15 +1,10 @@
 {
   "name": "something-special",
   "version": "0.5.5",
-  "type": "object",
-  "partials": {},
   "context": {},
-  "themes": [],
   "script": [],
   "i18n": {},
   "l10n": {},
-  "fields": {},
   "settings": "schema.json",
-  "dependencies": {},
-  "assetDir": "assets"
+  "dependencies": {}
 }

--- a/spec/components/weak-sauce/0.0.4/diversity.json
+++ b/spec/components/weak-sauce/0.0.4/diversity.json
@@ -1,18 +1,13 @@
 {
   "name":      "weak-sauce",
   "version":   "0.0.4",
-  "type":      "object",
   "thumbnail": "weak-sauce.png",
-  "partials":  {},
   "context": {},
-  "themes":   [],
   "script":   ["weak_sauce.js"],
   "i18n": {},
-  "l10n": {}, 
-  "fields":   {},
+  "l10n": {},
   "settings":  {},
   "dependencies": {
     "dummy" : ">0"
-  },
-  "assetDir":  "assets"
+  }
 }

--- a/spec/diversity.rb
+++ b/spec/diversity.rb
@@ -32,7 +32,6 @@ describe 'Component' do
     component.styles.should.equal(['/dummy/css/dummy.css'])
     component.scripts.to_a.should.equal(['/dummy/js/dummy1.js', '/dummy/js/dummy2.js'])
     component.dependencies.should.equal('something-special' => '>0.0.1')
-    component.type.should.equal('object')
     component.pagetype.should.equal(nil)
     component.context.should.equal({})
     component.settings.class.should.equal(Diversity::JsonSchema)
@@ -55,31 +54,31 @@ describe 'Component' do
     )
     registry = Diversity::Registry::Local.new(base_path: registry_path)
     it '...by Rubygems version' do
-      registry.installed?('dummy', Gem::Version.new('0.0.1')).should.equal(true)
+      registry.available?('dummy', Gem::Version.new('0.0.1')).should.equal(true)
       comp = registry.get_component('dummy', Gem::Version.new('0.0.1'))
       comp.name.should.equal('dummy')
       comp.version.to_s.should.equal('0.0.1')
     end
     it '...by exact version string' do
-      registry.installed?('dummy', '0.0.1').should.equal(true)
+      registry.available?('dummy', '0.0.1').should.equal(true)
       comp = registry.get_component('dummy', '0.0.1')
       comp.name.should.equal('dummy')
       comp.version.to_s.should.equal('0.0.1')
     end
     it '...by fuzzy version string' do
-      registry.installed?('dummy', '>0').should.equal(true)
+      registry.available?('dummy', '>0').should.equal(true)
       comp = registry.get_component('dummy', '>0')
       comp.name.should.equal('dummy')
       comp.version.to_s.should.equal('0.0.1')
     end
     it '...by fuzzy version string (take 2)' do
-      registry.installed?('dummy', '^0.0.1').should.equal(true)
+      registry.available?('dummy', '^0.0.1').should.equal(true)
       comp = registry.get_component('dummy', '^0.0.1')
       comp.name.should.equal('dummy')
       comp.version.to_s.should.equal('0.0.1')
     end
     it '...by fuzzy version string (take 3)' do
-      registry.installed?('something-special', '^0.5.0').should.equal(true)
+      registry.available?('something-special', '^0.5.0').should.equal(true)
       comp = registry.get_component('something-special', '^0.5.0')
       comp.name.should.equal('something-special')
       comp.version.to_s.should.equal('0.5.5')


### PR DESCRIPTION
- Never instantiate components unless get_component or get_matching_components are called.
- Remove uninstall_component from local repository
- Fix component files in spec so that they match the schema.
