### PR TITLE
Allow for a registry to skip component validation entirely.

### DIFF
--- a/lib/diversity/common.rb
+++ b/lib/diversity/common.rb
@@ -99,12 +99,13 @@ module Diversity
 
     # Loads a JSON resource, parses it and returns a Diversity::JsonObject
     #
-    # @param[String] resource
-    # @param[Class] klass
-    def load_json(resource, klass = JsonObject)
+    # @param [String] resource
+    # @param [Class] klass
+    # @param [Hash] options
+    def load_json(resource, klass = JsonObject, options = {})
       fail "Failed to load JSON from #{resource}" unless (data = safe_load(resource))
       begin
-        JsonObject[JSON.parse(data, symbolize_names: false), resource, klass]
+        JsonObject[JSON.parse(data, symbolize_names: false), resource, klass, options]
       rescue JSON::ParserError
         raise Diversity::Exception, "Failed to parse schema from #{resource}", caller
       end

--- a/lib/diversity/component.rb
+++ b/lib/diversity/component.rb
@@ -53,9 +53,12 @@ module Diversity
       @configuration = Configuration.new
       @options = DEFAULT_OPTIONS.keep_merge(options)
 
-      schema = JsonSchemaCache[MASTER_COMPONENT_SCHEMA]
+      schema = JsonSchemaCache[
+                 MASTER_COMPONENT_SCHEMA,
+                 { skip_validation: @options[:skip_validation] }
+               ]
       begin
-        schema.validate(spec) unless @options[:skip_validation]
+        schema.validate(spec)
       rescue Diversity::Exception => err
         puts "Bad #{base_url}/diversity.json - #{err}\n\n"
       end
@@ -232,12 +235,13 @@ module Diversity
       @configuration.pagetype = hsh.fetch('pagetype', nil)
       @configuration.context = hsh.fetch('context', {})
       settings = hsh.fetch('settings', {})
+      schema_options = @options[:skip_validation] ? { skip_validation: true } : {}
       if settings.is_a?(Hash)
-        @configuration.settings = JsonSchema.new(settings, nil)
+        @configuration.settings = JsonSchema.new(settings, nil, schema_options)
       elsif settings.is_a?(String)
-        @configuration.settings = JsonSchema.new({}, settings)
+        @configuration.settings = JsonSchema.new({}, settings, schema_options)
       else
-        @configuration.settings = JsonSchema.new({}, nil)
+        @configuration.settings = JsonSchema.new({}, nil, schema_options)
       end
       @configuration.angular = hsh.fetch('angular', nil)
       # If set to true, use component name

--- a/lib/diversity/core_extensions.rb
+++ b/lib/diversity/core_extensions.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # https://www.ruby-forum.com/topic/142809
 class Hash
   # Recursive merge of Hash
@@ -11,7 +12,6 @@ class Hash
         next
       end
       target[key] = hash[key]
-      #target.update(hash) { |_, *values| values.flatten.uniq }
     end
     target
   end

--- a/lib/diversity/engine.rb
+++ b/lib/diversity/engine.rb
@@ -45,18 +45,18 @@ module Diversity
       settings.add_component(component)
 
       # Get component schema
-      schema = component.settings.data
+      schema = component.settings
 
       # Validate
       debug(
         "\n\n/#{path.join('/')} - #{component.name}:#{component.version}: " \
         "#{component_settings.inspect}\n"
       )
-      validation = JSON::Validator.fully_validate(schema, component_settings)
+      validation = schema.validate(component_settings)
       debug("Validation failed:\n#{validation.join("\n")}") unless validation.empty?
 
       # Traverse the component_settings to expand sub-components
-      expanded_settings = expand_settings(schema, component_settings, context, path, component)
+      expanded_settings = expand_settings(schema.data, component_settings, context, path, component)
 
       render_template(component, context, expanded_settings, path)
     end

--- a/lib/diversity/json_object.rb
+++ b/lib/diversity/json_object.rb
@@ -7,10 +7,11 @@ module Diversity
 
     attr_reader :data, :source
 
-    def initialize(data, source = nil)
+    def initialize(data, source = nil, options = {})
       fail 'First parameter must be a hash' unless data.is_a?(Hash)
       @data = data
       @source = source
+      @options = options
     end
 
     # Returns the current object as a JSON string
@@ -117,9 +118,10 @@ module Diversity
     # @param [Hash] data
     # @param [String] source
     # @param [Class] klass
-    def self.[](data, source = nil, klass = JsonObject)
+    # @param [Hash] options
+    def self.[](data, source = nil, klass = JsonObject, options = {})
       fail 'Must be a subclass of Diversity::JsonObject' unless klass <= JsonObject
-      klass.new(data, source)
+      klass.new(data, source, options)
     end
 
     def self.traverse(data, path = [], &block)

--- a/lib/diversity/json_schema.rb
+++ b/lib/diversity/json_schema.rb
@@ -1,23 +1,30 @@
-require 'json-schema'
+# encoding: utf-8
 require_relative 'json_object'
 
 module Diversity
   # An ordinary JsonObject blessed with the ability to validate other
   # JsonObjects
   class JsonSchema < JsonObject
+    DEFAULT_OPTIONS = { skip_validation: false }
+
+    attr_reader :options
+
+    def initialize(data, source = nil, options = {})
+      super(data, source)
+      @options = DEFAULT_OPTIONS.keep_merge(options)
+    end
+
     # Validates the specified JSON data against the current object
     #
     # @param [Diversity::JsonObject|Hash|String] data
-    # @return [true]
+    # @return [Array]
     def validate(data)
+      # Bail early if validation is turned off
+      return [] if @options[:skip_validation]
       # Automatically convert Diversity::JsonObjects to hashes
       data = data.data if data.is_a?(Diversity::JsonObject)
-      errors = JSON::Validator.fully_validate(@data, data)
-      fail Diversity::Exception,
-        "Configuration does not match schema. Errors:\n#{errors.join("\n")}",
-        caller unless errors.empty?
-      true
+      require 'json-schema'
+      JSON::Validator.fully_validate(@data, data)
     end
   end
-
 end

--- a/lib/diversity/json_schema_cache.rb
+++ b/lib/diversity/json_schema_cache.rb
@@ -17,11 +17,13 @@ module Diversity
     # Returns the JSON schema denoted by key
     #
     # @param [String] key
+    # @param [Hash] options
     # @return Diversity::JsonSchema
-    def self.[](key)
-      return @cache[key] if @cache.key?(key)
-      @cache[key] = load_json(key, JsonSchema)
-      @cache[key]
+    def self.[](key, options = {})
+      cache_key = "#{key}##{Digest::MD5.hexdigest(options.to_s)}"
+      return @cache[cache_key] if @cache.key?(cache_key)
+      @cache[cache_key] = load_json(key, JsonSchema, options)
+      @cache[cache_key]
     end
 
     # Purges one (or all) items from the cache


### PR DESCRIPTION
Allow a registry (or a component) to bypass schema validation entirely by setting the option skip_validation to true. This is false by default.
