### PR TITLE
Fixing sub-component loading in engine

### DIFF
--- a/lib/diversity/component.rb
+++ b/lib/diversity/component.rb
@@ -58,8 +58,12 @@ module Diversity
                  { validate_spec: @options[:validate_spec] }
                ]
 
-      schema.validate(spec)
       @raw = parse_config(spec)
+
+      validation = schema.validate(@raw)
+      raise Diversity::Exception, "Configuration is not valid:\n" + validation.join("\n"), caller if
+        validation.length > 0
+
       @checksum = Digest::SHA1.hexdigest(dump)
       @assets = {}
       populate(@raw)

--- a/lib/diversity/component.rb
+++ b/lib/diversity/component.rb
@@ -57,12 +57,9 @@ module Diversity
                  MASTER_COMPONENT_SCHEMA,
                  { validate_spec: @options[:validate_spec] }
                ]
-      begin
-        schema.validate(spec)
-        @raw = parse_config(spec)
-      rescue Diversity::Exception => err
-        puts "Bad #{base_url}/diversity.json - #{err}\n\n"
-      end
+
+      schema.validate(spec)
+      @raw = parse_config(spec)
       @checksum = Digest::SHA1.hexdigest(dump)
       @assets = {}
       populate(@raw)

--- a/lib/diversity/engine.rb
+++ b/lib/diversity/engine.rb
@@ -42,7 +42,7 @@ module Diversity
     # @param [Hash]   component_settings  Settings for this component rendering.
     # @param [Array]  path                Array representing json path from root.
     #
-    # @return [Hash|String]
+    # @return [String]
     def render(component, context = {}, component_settings = {}, path = [])
       settings.add_component(component)
 
@@ -155,8 +155,8 @@ module Diversity
 
     def get_component(name, version = nil)
       component = @options[:registry].get_component(name, version)
-      fail "No component from #{sub_settings['component']}" unless sub_component
-      settings.add_component(component)
+      fail "No component from #{sub_settings['component']}" unless component
+      component
     end
 
     class << self

--- a/spec/components_for_engine/sub_one/1.1.2/diversity.json
+++ b/spec/components_for_engine/sub_one/1.1.2/diversity.json
@@ -1,0 +1,14 @@
+{
+  "name": "sub_one",
+  "version": "1.1.2",
+  "template": "template.html",
+  "settings": {
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "default": "No title given"
+      }
+    }
+  }
+}

--- a/spec/components_for_engine/sub_one/1.1.2/template.html
+++ b/spec/components_for_engine/sub_one/1.1.2/template.html
@@ -1,0 +1,1 @@
+·:·{{ settings.title }}·:·

--- a/spec/components_for_engine/toponent/0.0.1/diversity.json
+++ b/spec/components_for_engine/toponent/0.0.1/diversity.json
@@ -1,0 +1,14 @@
+{
+  "name": "toponent",
+  "version": "0.0.1",
+  "template": "template.html",
+  "settings": {
+    "type": "object",
+    "properties": {
+      "sub_object": {
+        "type": "object",
+        "format": "diversity"
+      }
+    }
+  }
+}

--- a/spec/components_for_engine/toponent/0.0.1/template.html
+++ b/spec/components_for_engine/toponent/0.0.1/template.html
@@ -1,0 +1,1 @@
+Here is a title: {{ settings.sub_object.componentHTML }}.

--- a/spec/diversity.rb
+++ b/spec/diversity.rb
@@ -111,6 +111,20 @@ describe 'Component' do
       .should.match(/Failed to parse configuration/)
   end
 
+  should 'fail when config does not validate against diversity schema' do
+    ->() { Diversity::Component.new('{}', {validate_spec: true}) }
+      .should.raise(Diversity::Exception).message
+      .should.match(
+        /The property '#\/' did not contain a required property of 'name' in schema/
+      )
+  end
+
+  should 'NOT fail when config should not be validated against diversity schema' do
+    # Should not raise error.
+    Diversity::Component.new('{}', {validate_spec: false})
+      .class.should.equal(Diversity::Component)
+  end
+
 =begin
   # This test should be reenabled when when validation is enabled again
   should 'fail when settings file cannot be parsed as valid JSON' do

--- a/spec/diversity.rb
+++ b/spec/diversity.rb
@@ -176,34 +176,30 @@ describe 'Component' do
 
 end
 
-=begin
-# Fix later
 describe 'Engine' do
-  should 'be able to render a simple component' do
-    registry_path = File.expand_path(Dir.mktmpdir)
-    begin
-      registry = Diversity::Registry::Local.new(registry_path)
-      registry.install_component(
-        'http://diversity.io/textalk-webshop-native-components/tws-custom-html/raw/master/diversity.json'
-      )
-      component = registry.get_component('tws-custom-html')
-      engine = Diversity::Engine.new({registry: registry})
-      context = {'lang' => 'sv'}
-      settings = Diversity::JsonObject.new(
-        {
-          'custom_html' => {
-            'lang' => {
-              'en' => "<p>I'm a custom component!</p>",
-              'sv' => "<p>Jag är en anpassad component!</p>"
-            }
-          }
+  should 'render sub-components from registry when used in settings' do
+    registry_path = File.expand_path(File.join(File.dirname(__FILE__), 'components_for_engine'))
+    registry = Diversity::Registry::Local.new(
+      base_path: registry_path,
+      base_url:  'fubar:',
+    )
+
+    component = registry.get_component('toponent')
+
+    engine = Diversity::Engine.new({registry: registry})
+    #context = {'lang' => 'sv'}
+    settings = {
+      'sub_object' => {
+        'component' => 'sub_one',
+        'version'   => '1.1',
+        'settings' => {
+          'title' => 'FUBAR'
         }
-      )
-      engine.render(component, context, settings).inspect
-      true.should.equal(true)
-    ensure
-      FileUtils.remove_entry_secure registry_path
-    end
+      }
+    }
+
+    engine.render(component, {}, settings).should.equal(
+      "Here is a title: ·:·FUBAR·:·\n.\n"
+    )
   end
 end
-=end


### PR DESCRIPTION
Fixes #31 

I also considered the spec “should fail when config file cannot be parsed as valid JSON” to be correct, so component now crashes again if the json is not json.