### PR TITLE
Use standard Logger interface

### DIFF
--- a/lib/diversity/component.rb
+++ b/lib/diversity/component.rb
@@ -7,6 +7,7 @@ require 'json-rpc-client'
 require 'rake/file_list'
 require 'rubygems/requirement'
 require 'rubygems/version'
+require 'null_logger'
 require_relative 'common'
 require_relative 'exception'
 require_relative 'json_schema_cache'
@@ -25,6 +26,7 @@ module Diversity
     DEFAULT_OPTIONS = {
       base_url:      nil,
       base_path:     nil,  # Can be set to something more readily readable than base_url
+      logger:        NullLogger.instance,
       validate_spec: false
     }
 
@@ -52,6 +54,7 @@ module Diversity
     def initialize(spec, options)
       @configuration = Configuration.new
       @options = DEFAULT_OPTIONS.keep_merge(options)
+      @logger = @options[:logger]
 
       schema = JsonSchemaCache[
                  MASTER_COMPONENT_SCHEMA,
@@ -96,7 +99,7 @@ module Diversity
         end
 
         unless settings.key?('type')
-          puts "#{self} has context with no type: #{key}"
+          @logger.debug("#{self} has context with no type: #{key}")
           resolved_context[key] = settings
           next
         end

--- a/lib/diversity/engine.rb
+++ b/lib/diversity/engine.rb
@@ -55,7 +55,7 @@ module Diversity
       # Validate if told to and someone could see it
       if @options[:validate_settings]
         validation = schema.validate(component_settings)
-        @logger.debug("Validation failed:\n#{validation.join("\n")}") unless validation.empty?
+        @logger.warn("Validation failed:\n#{validation.join("\n")}") unless validation.empty?
       end
 
       # Traverse the component_settings to expand sub-components
@@ -233,7 +233,7 @@ module Diversity
         text.gsub(/lang/, context[:language] || 'sv')
       end
 
-      @logger.debug("Rendering #{component}\n") # with mustache:\n#{mustache_settings}\n\n"
+      @logger.info("Rendering #{component}\n") # with mustache:\n#{mustache_settings}\n\n"
 
       # Return rendered data
       Mustache.render(template_mustache, mustache_settings)

--- a/lib/diversity/registry/base.rb
+++ b/lib/diversity/registry/base.rb
@@ -4,9 +4,6 @@ module Diversity
     # This class is the superclass of all registry classes
     class Base
       include Common
-      
-      LOGLEVEL_DEFAULT = 1
-      LOGLEVEL_VERBOSE = 2
 
       # Checks whether a component with a specified version is available.
       #
@@ -122,14 +119,8 @@ module Diversity
           end
           cache_init_messages << "  - Using adapter settings #{adapter_options.inspect}"
         end
-        cache_init_messages.each { |msg| log("#{msg}\n") }
+        cache_init_messages.each { |msg| @logger.debug(msg) }
         nil
-      end
-
-      # Logs a message to the logger if there exists a logger and the log level is equal or greater
-      # than the message's log level
-      def log(message, level = LOGLEVEL_DEFAULT)
-        @options[:logger] << message if @options[:logger] && @options[:log_level] >= level
       end
     end
   end

--- a/lib/diversity/registry/local.rb
+++ b/lib/diversity/registry/local.rb
@@ -2,6 +2,7 @@
 require 'fileutils'
 require 'addressable/uri'
 require 'fileutils'
+require 'null_logger'
 require_relative '../common.rb'
 require_relative '../component.rb'
 require_relative '../exception.rb'
@@ -25,8 +26,7 @@ module Diversity
           shared: false,
           ttl: 3600
         },
-        log_level: LOGLEVEL_DEFAULT,
-        logger: nil,
+        logger: NullLogger.instance,
         validate_spec: false
       }
 
@@ -40,6 +40,7 @@ module Diversity
       def initialize(options = {})
         @options = DEFAULT_OPTIONS.keep_merge(options)
         @options[:base_path] = File.expand_path(@options[:base_path])
+        @logger = @options[:logger]
         fileutils.mkdir_p(@options[:base_path]) unless File.exist?(@options[:base_path])
         init_cache(@options[:cache_options])
       end
@@ -108,8 +109,7 @@ module Diversity
                 res[component] = [] unless res.key?(component)
                 res[component] << Gem::Version.new(version)
               rescue Diversity::Exception => e
-                log("Caught an exception trying to put #{cfg} in list of installed components.\n")
-                log("#{e.inspect}\n")
+                @logger.warn("Exception adding #{cfg} to list of components.\n#{e.inspect}")
               end
               res
             end.each_pair do |component, versions|

--- a/lib/diversity/registry/local.rb
+++ b/lib/diversity/registry/local.rb
@@ -90,6 +90,7 @@ module Diversity
             validate_spec: @options[:validate_spec],
             base_url:        base_url,
             base_path:       dir,
+            logger:          @logger,
           }
           Component.new(spec, options)
         end
@@ -109,7 +110,7 @@ module Diversity
                 res[component] = [] unless res.key?(component)
                 res[component] << Gem::Version.new(version)
               rescue Diversity::Exception => e
-                @logger.warn("Exception adding #{cfg} to list of components.\n#{e.inspect}")
+                @logger.error("Exception adding #{cfg} to list of components.\n#{e.inspect}")
               end
               res
             end.each_pair do |component, versions|


### PR DESCRIPTION
Using standard Logger interface with NullLogger as default logger.

Simpler, less code, easier to use and same possibilities outside.